### PR TITLE
pc - fix ci/cd to enforce test coverage, refactor jobs tests

### DIFF
--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -24,8 +24,10 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report 
-    - name: Upload to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: bash <(curl -s https://codecov.io/bash)
+      run: mvn -B test jacoco:report verify
+    - name: Upload jacoco report to Artifacts
+      if: always() # always upload artifacts, even if tests fail
+      uses: actions/upload-artifact@v2
+      with:
+        name: jacoco-report
+        path: target/site/jacoco/*

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -26,9 +26,11 @@ jobs:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test 
     - name: Pitest
-      run: mvn test org.pitest:pitest-maven:mutationCoverage
+      run: mvn test org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100 
     - name: Upload Pitest to Artifacts
+      if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v2
       with:
         name: pitest-mutation-testing
         path: target/pit-reports/* 
+

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,41 @@
                             <goal>report</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>CLASS</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>0</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,13 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>4.2.0</version>
-          </dependency>
+        </dependency>
+
+        <!-- to manage security context in async threads; see: https://www.baeldung.com/spring-security-async-principal-propagation -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/HappierCowsApplication.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/HappierCowsApplication.java
@@ -6,6 +6,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableAsync
@@ -15,4 +19,21 @@ public class HappierCowsApplication {
     SpringApplication.run(HappierCowsApplication.class, args);
   }
 
+  // See: https://www.baeldung.com/spring-security-async-principal-propagation
+  @Bean
+  public DelegatingSecurityContextAsyncTaskExecutor taskExecutor(ThreadPoolTaskExecutor delegate) {
+    return new DelegatingSecurityContextAsyncTaskExecutor(delegate);
+  }
+
+  // See: https://www.baeldung.com/spring-security-async-principal-propagation
+  @Bean
+  public ThreadPoolTaskExecutor threadPoolTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(2);
+    executor.setMaxPoolSize(2);
+    executor.setQueueCapacity(500);
+    executor.setThreadNamePrefix("HappierCows-");
+    executor.initialize();
+    return executor;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJob;
+import edu.ucsb.cs156.happiercows.jobs.TestJob;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
 
@@ -53,15 +55,12 @@ public class JobsController extends ApiController {
         @ApiParam("fail") @RequestParam Boolean fail, 
         @ApiParam("sleepMs") @RequestParam Integer sleepMs
     ) {
+        TestJob testJob = TestJob.builder()
+        .fail(fail)
+        .sleepMs(sleepMs)
+        .build();
 
-        return jobService.runAsJob(ctx -> {
-            ctx.log("Hello World! from test job!");
-            Thread.sleep(sleepMs);
-            if (fail) {
-                throw new Exception("Fail!");
-            }
-            ctx.log("Goodbye from test job!");
-          });
+        return jobService.runAsJob(testJob);
     }
 
     @ApiOperation(value = "Launch Job to Milk the Cows")
@@ -69,12 +68,8 @@ public class JobsController extends ApiController {
     @PostMapping("/launch/milkjob")
     public Job launchMilkJob(
     ) {
-
-        return jobService.runAsJob(ctx -> {
-            ctx.log("Starting to milk the cows");
-            ctx.log("This is where the code to milk the cows will go.");
-            ctx.log("Cows have been milked!");
-          });
+        MilkTheCowsJob milkTheCowsJob = MilkTheCowsJob.builder().build();
+        return jobService.runAsJob(milkTheCowsJob);
     }
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import lombok.Builder;
+
+@Builder
+public class MilkTheCowsJob implements JobContextConsumer {
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        ctx.log("Starting to milk the cows");
+        ctx.log("This is where the code to milk the cows will go.");
+        ctx.log("Cows have been milked!");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/TestJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/TestJob.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import lombok.Builder;
+
+@Builder
+public class TestJob implements JobContextConsumer {
+
+    private boolean fail;
+    private int sleepMs;
+    
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+            // Ensure this is not null 
+            Authentication authentication =  SecurityContextHolder.getContext().getAuthentication();
+
+            ctx.log("Hello World! from test job!");
+            if (authentication == null) {
+                ctx.log("authentication is null");
+            } else {
+                ctx.log("authentication is not null");
+            }
+            Thread.sleep(sleepMs);
+            if (fail) {
+                throw new Exception("Fail!");
+            }
+            ctx.log("Goodbye from test job!");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/jobs/JobContext.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/jobs/JobContext.java
@@ -15,6 +15,8 @@ public class JobContext {
     log.info("Job %s: %s".formatted(job.getId(), message));
     String previousLog = job.getLog() == null ? "" : (job.getLog() + "\n");
     job.setLog(previousLog + message);
-    jobsRepository.save(job);
+    if (jobsRepository != null) {
+      jobsRepository.save(job);
+    }  
   }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/jobs/JobService.java
@@ -6,8 +6,6 @@ import edu.ucsb.cs156.happiercows.services.CurrentUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,7 +28,7 @@ public class JobService {
       .build();
 
     jobsRepository.save(job);
-    self.runJobAsync(job, jobFunction, SecurityContextHolder.getContext());
+    self.runJobAsync(job, jobFunction);
 
     return job;
   }
@@ -38,10 +36,8 @@ public class JobService {
   
 
   @Async
-  public void runJobAsync(Job job, JobContextConsumer jobFunction, SecurityContext securityContext) {
+  public void runJobAsync(Job job, JobContextConsumer jobFunction) {
     JobContext context = new JobContext(jobsRepository, job);
-
-    SecurityContextHolder.setContext(securityContext);
 
     try {
       jobFunction.accept(context);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -233,7 +233,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .endingDate(someOtherTime)
         .degradationRate(50.0)
-        .showLeaderboard(false)
+        .showLeaderboard(true)
         .build();
 
     Commons commons = Commons.builder()
@@ -244,7 +244,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .endingDate(someOtherTime)
         .degradationRate(50.0)
-        .showLeaderboard(false)
+        .showLeaderboard(true)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -265,6 +265,9 @@ public class CommonsControllerTests extends ControllerTestCase {
     commons.setMilkPrice(parameters.getMilkPrice());
     parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
     commons.setDegradationRate(parameters.getDegradationRate());
+
+    parameters.setShowLeaderboard(parameters.getShowLeaderboard());
+    commons.setShowLeaderboard(parameters.getShowLeaderboard());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -644,13 +647,9 @@ public class CommonsControllerTests extends ControllerTestCase {
               .andExpect(status().is(404)).andReturn();
       verify(commonsRepository, times(1)).findById(2L);
 
-
-
-      String responseString = response.getResponse().getContentAsString();
-
       String expectedString = "{\"message\":\"Commons with id 2 not found\",\"type\":\"EntityNotFoundException\"}";
 
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+      Map<String, Object> expectedJson = mapper.readValue(expectedString, new TypeReference<Map<String,Object>>() {} );
       Map<String, Object> jsonResponse = responseToJson(response);
       assertEquals(expectedJson, jsonResponse);
   }
@@ -721,7 +720,6 @@ public class CommonsControllerTests extends ControllerTestCase {
     expectedCommons.add(Commons1);
 
     List<CommonsPlus> expectedCommonsPlus = new ArrayList<CommonsPlus>();
-    List<CommonsPlus> dummy = new ArrayList<CommonsPlus>();
     CommonsPlus CommonsPlus1 = CommonsPlus.builder()
         .commons(Commons1)
         .totalCows(50)

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,129 +46,145 @@ import lombok.extern.slf4j.Slf4j;
 @AutoConfigureDataJpa
 public class JobsControllerTests extends ControllerTestCase {
 
-  @MockBean
-  JobsRepository jobsRepository;
+    @MockBean
+    JobsRepository jobsRepository;
 
-  @MockBean
-  UserRepository userRepository;
+    @MockBean
+    UserRepository userRepository;
 
-  @Autowired
-  JobService jobService;
+    @Autowired
+    JobService jobService;
 
-  @Autowired
-  ObjectMapper objectMapper;
+    @Autowired
+    ObjectMapper objectMapper;
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void admin_can_get_all_jobs() throws Exception {
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_get_all_jobs() throws Exception {
 
-    // arrange
+        // arrange
 
-    Job job1 = Job.builder().log("this is job 1").build();
-    Job job2 = Job.builder().log("this is job 2").build();
+        Job job1 = Job.builder().log("this is job 1").build();
+        Job job2 = Job.builder().log("this is job 2").build();
 
-    ArrayList<Job> expectedJobs = new ArrayList<>();
-    expectedJobs.addAll(Arrays.asList(job1, job2));
+        ArrayList<Job> expectedJobs = new ArrayList<>();
+        expectedJobs.addAll(Arrays.asList(job1, job2));
 
-    when(jobsRepository.findAll()).thenReturn(expectedJobs);
+        when(jobsRepository.findAll()).thenReturn(expectedJobs);
 
-    // act
-    MvcResult response = mockMvc.perform(get("/api/jobs/all"))
-        .andExpect(status().isOk()).andReturn();
+        // act
+        MvcResult response = mockMvc.perform(get("/api/jobs/all"))
+                .andExpect(status().isOk()).andReturn();
 
-    // // assert
+        // // assert
 
-    verify(jobsRepository, times(1)).findAll();
-    String expectedJson = mapper.writeValueAsString(expectedJobs);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString);
-  }
+        verify(jobsRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedJobs);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void admin_can_launch_test_job() throws Exception {
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_test_job() throws Exception {
 
-    // arrange
+        // arrange
 
-    User user = currentUserService.getUser();
+        User user = currentUserService.getUser();
 
-    Job jobStarted = Job.builder()
-        .id(0L)
-        .createdBy(user)
-        .createdAt(null)
-        .updatedAt(null)
-        .status("running")
-        .log("Hello World! from test job!")
-        .build();
+        Job jobStarted = Job.builder()
+                .id(0L)
+                .createdBy(user)
+                .createdAt(null)
+                .updatedAt(null)
+                .status("running")
+                .log("Hello World! from test job!\nauthentication is not null")
+                .build();
 
-    Job jobCompleted = Job.builder()
-        .id(0L)
-        .createdBy(user)
-        .createdAt(null)
-        .updatedAt(null)
-        .status("complete")
-        .log("Hello World! from test job!\nGoodbye from test job!")
-        .build();
+        Job jobCompleted = Job.builder()
+                .id(0L)
+                .createdBy(user)
+                .createdAt(null)
+                .updatedAt(null)
+                .status("complete")
+                .log("Hello World! from test job!\nauthentication is not null\nGoodbye from test job!")
+                .build();
 
-    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobCompleted);
+        when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobCompleted);
 
-    // act
-    MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=2000").with(csrf()))
-        .andExpect(status().isOk()).andReturn();
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=2000").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
 
-    // assert
-    String responseString = response.getResponse().getContentAsString();
-    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
 
-    assertEquals("running", jobReturned.getStatus());
+        assertEquals("running", jobReturned.getStatus());
 
-    await().atMost(1, SECONDS)
-        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
-    await().atMost(10, SECONDS)
-        .untilAsserted(() -> verify(jobsRepository, times(4)).save(eq(jobCompleted)));
-  }
+        await().atMost(1, SECONDS)
+                .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobStarted)));
+        await().atMost(10, SECONDS)
+                .untilAsserted(() -> verify(jobsRepository, times(5)).save(eq(jobCompleted)));
+    }
 
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void admin_can_launch_test_job_that_fails() throws Exception {
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_test_job_that_fails() throws Exception {
 
-    // arrange
+        // arrange
 
-    User user = currentUserService.getUser();
+        User user = currentUserService.getUser();
 
-    Job jobStarted = Job.builder()
-        .id(0L)
-        .createdBy(user)
-        .createdAt(null)
-        .updatedAt(null)
-        .status("running")
-        .log("Hello World! from test job!")
-        .build();
+        Job jobStarted = Job.builder()
+                .id(0L)
+                .createdBy(user)
+                .createdAt(null)
+                .updatedAt(null)
+                .status("running")
+                .log("Hello World! from test job!\nauthentication is not null")
+                .build();
 
-    Job jobFailed = Job.builder()
-        .id(0L)
-        .createdBy(user)
-        .createdAt(null)
-        .updatedAt(null)
-        .status("error")
-        .log("Hello World! from test job!\nFail!")
-        .build();
+        Job jobFailed = Job.builder()
+                .id(0L)
+                .createdBy(user)
+                .createdAt(null)
+                .updatedAt(null)
+                .status("error")
+                .log("Hello World! from test job!\nauthentication is not null\nFail!")
+                .build();
 
-    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobFailed);
+        when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobFailed);
 
-    // act
-    MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
-        .andExpect(status().isOk()).andReturn();
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
 
-    String responseString = response.getResponse().getContentAsString();
-    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+        String responseString = response.getResponse().getContentAsString();
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
 
-    assertEquals("running", jobReturned.getStatus());
+        assertEquals("running", jobReturned.getStatus());
 
-    await().atMost(1, SECONDS)
-        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
+        await().atMost(1, SECONDS)
+                .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobStarted)));
 
-    await().atMost(10, SECONDS)
-        .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobFailed)));
-  }
+        await().atMost(10, SECONDS)
+                .untilAsserted(() -> verify(jobsRepository, times(4)).save(eq(jobFailed)));
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_milk_the_cows_job() throws Exception {
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/milkjob").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        log.info("responseString={}", responseString);
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+        assertNotNull(jobReturned.getStatus());
+    }   
+
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+
+public class MilkTheCowsJobTests {
+    @Test
+    void test_log_output() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        // Act
+        MilkTheCowsJob milkTheCowsJob = MilkTheCowsJob.builder()
+                .build();
+        milkTheCowsJob.accept(ctx);
+
+        // Assert
+
+        String expected = "Starting to milk the cows\n" +
+                "This is where the code to milk the cows will go.\n" +
+                "Cows have been milked!";
+
+        assertEquals(expected, jobStarted.getLog());
+
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/TestJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/TestJobTests.java
@@ -1,0 +1,64 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration 
+public class TestJobTests {
+
+    @Test
+    void test_log_output_with_no_user() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        // Act
+        TestJob testJob = TestJob.builder()
+                .sleepMs(0)
+                .fail(false)
+                .build();
+        testJob.accept(ctx);
+
+        String expected = """
+            Hello World! from test job!
+            authentication is null
+            Goodbye from test job!""";
+        // Assert
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    @WithMockUser(roles = { "ADMIN" })
+    void test_log_output_with_mock_user() throws Exception {
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        // Act
+        TestJob testJob = TestJob.builder()
+                .sleepMs(0)
+                .fail(false)
+                .build();
+        testJob.accept(ctx);
+
+        String expected = """
+                Hello World! from test job!
+                authentication is not null
+                Goodbye from test job!""";
+        // Assert
+        assertEquals(expected, jobStarted.getLog());
+    }
+}


### PR DESCRIPTION
In this PR, we tighten up the CI/CD pipeline to require:
* 100% line coverage and branch coverage for GitHub Action 12 to pass (jacoco)
* 100% mutation coverage for GitHub Action 14 to pass (pitest)

We also refactor the jobs system to be easier to test; specifically we separate job logic from the asynchronous jobs system, so that job logic can be tested with synchronous tests (which are much easier to write).   We only test the async logic with the TestJob, not every single job.