### PR TITLE
jv - update join a commons list

### DIFF
--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -47,6 +47,7 @@ export default function HomePage() {
 
   let navigate = useNavigate();
   const visitButtonClick = (id) => { navigate("/play/" + id) };
+  const list_diff = (a, b) => a.filter(c => !b.some((e, _i) => e.id === c.id ));
 
   return (
     <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
@@ -55,7 +56,7 @@ export default function HomePage() {
         <Container>
           <Row>
             <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
-            <Col sm><CommonsList commonList={commons} title="Join A Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
+            <Col sm><CommonsList commonList={list_diff(commons, commonsJoined)} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
           </Row>
         </Container>
       </BasicLayout>

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -85,8 +85,13 @@ describe("HomePage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId("commonsCard-button-Join-1")).toBeInTheDocument();
-        const joinButton = screen.getByTestId("commonsCard-button-Join-1");
+        expect(await screen.findByTestId("commonsCard-button-Visit-1")).toBeInTheDocument();
+        const visit1Button = screen.getByTestId("commonsCard-button-Visit-1");
+        fireEvent.click(visit1Button);
+
+        expect(await screen.findByTestId("commonsCard-button-Join-4")).toBeInTheDocument();
+        const joinButton = screen.getByTestId("commonsCard-button-Join-4");
         fireEvent.click(joinButton);
+
     });
 });


### PR DESCRIPTION
In this PR, we change the following for Home page: 
- "Join A Commons" has been changed to "Join A New Commons" 
- Commons that are already joined no longer appear in "Join A Commons" list
- Tests for Home page has been modified to accommodate previous changes. 

Closes #22 