### PR TITLE
SY - Change visibility on Leaderboard page so table is readable

### DIFF
--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,16 +48,8 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, 
-    '&::before': {
-      content: "",
-      position: "absolute",
-      left: 0,
-      right: 0,
-      top: 0,
-      bottom: 0,
-      backgroundColor: "rgba(255,255,255,1)",
-    }}}>
+    <div style={{ backgroundSize: 'cover', background: linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.5)), backgroundImage: `url(${Background})`, 
+}}>
         <BasicLayout>
             <div className="pt-2">
                 <h1>Leaderboard</h1>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,15 +48,15 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: 'relative', 
-    '&::after': {
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, 
+    '&::before': {
       content: "",
       position: "absolute",
       left: 0,
       right: 0,
       top: 0,
       bottom: 0,
-      backgroundColor: "rgba(255,255,255,0.5)",
+      backgroundColor: "rgba(255,255,255,1)",
     }}}>
         <BasicLayout>
             <div className="pt-2">

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,17 +48,20 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', background: linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.5)), backgroundImage: `url(${Background})`, 
-}}>
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
         <BasicLayout>
-            <div className="pt-2">
-                <h1>Leaderboard</h1>
-                {
-                  showLeaderboard?
-                  (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser}/>) :
-                  (<p>You're not authorized to see the leaderboard.</p>)
-                }
-            </div>
+          <Container>
+            <Card>
+              <div className="pt-2">
+                  <h1>Leaderboard</h1>
+                  {
+                    showLeaderboard?
+                    (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser}/>) :
+                    (<p>You're not authorized to see the leaderboard.</p>)
+                  }
+              </div>
+            </Card>
+          </Container>
         </BasicLayout>
     </div>
   )

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -49,7 +49,7 @@ export default function LeaderboardPage() {
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
     <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: 'relative', 
-    '&::before': {
+    '&::after': {
       content: "",
       position: "absolute",
       left: 0,

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,7 +48,7 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: relative, 
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: 'relative', 
     '&::before': {
       content: "",
       position: "absolute",

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Container, Card } from "react-bootstrap";
 
 import { useParams } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,13 +48,22 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, color:"white", 
+    '&::before': {
+      content: "",
+      position: "absolute",
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      background: "rgba(255,255,255,0.5)",
+    }}}>
         <BasicLayout>
             <div className="pt-2">
                 <h1>Leaderboard</h1>
                 {
                   showLeaderboard?
-                  (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />) :
+                  (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser}/>) :
                   (<p>You're not authorized to see the leaderboard.</p>)
                 }
             </div>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,7 +48,7 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, color:"white", 
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: relative, 
     '&::before': {
       content: "",
       position: "absolute",
@@ -56,7 +56,7 @@ export default function LeaderboardPage() {
       right: 0,
       top: 0,
       bottom: 0,
-      background: "rgba(255,255,255,0.5)",
+      backgroundColor: "rgba(255,255,255,0.5)",
     }}}>
         <BasicLayout>
             <div className="pt-2">


### PR DESCRIPTION
In this PR, the leaderboard table is added into a card with a white background on the Leaderboard page so that it is more readable and does not blend into the background image.

![pr](https://user-images.githubusercontent.com/77772441/204406744-235691b4-c084-4c07-89e2-52576f247478.png)

Closes #23 
