### PR TITLE
ad - Add a variable for how many players are in a common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,14 @@
                     <timestampedReports>false</timestampedReports>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>16</source>
+                    <target>16</target>
+                </configuration>
+            </plugin>
 
 
         </plugins>

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -33,6 +33,8 @@ public class Commons
   private double degradationRate;
   private boolean showLeaderboard;
 
+  private int totalPlayers;
+
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons",
     joinColumns = @JoinColumn(name = "commons_id", referencedColumnName = "id"),

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -28,6 +28,8 @@ public class CreateCommonsParams {
   private double milkPrice;
   @NumberFormat
   private double startingBalance;
+  @NumberFormat
+  private int totalPlayers;
   @NumberFormat private double degradationRate;
   @DateTimeFormat
   private LocalDateTime startingDate;

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -76,6 +76,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .totalPlayers(0)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -87,6 +88,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .totalPlayers(0)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -124,6 +126,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(0)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .totalPlayers(0)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -135,6 +138,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(0)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .totalPlayers(0)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -169,6 +173,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(-8.49)
+        .totalPlayers(0)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -178,6 +183,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(-8.49)
+        .totalPlayers(0)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);


### PR DESCRIPTION
I see that in the Kanban board that the issue is "NOT APPROVED", and that a new variable doesn't have to be introduced.

Well I thought that if in the "CommonsOverview" component that it is expecting "commons.totalPlayers" as a field for displaying the number of players in a common, and the "totalPlayers" field wasn't initially defined in the Commons entity, then I thought it must be added.

So I added the field, but simply used the "toCommonsPlus" function defined in "CommonsController" to set the "getNumUsers" to totalPlayers. I made this change in several "CommonsController" endpoints: for instance "/all", "/update", and the main one that expects a commonsID value as a parameter (the endpoint that the frontend components use). So I haven't actually defined my own implementation of how to get the current number of players in a common.

You also say the following "But, if you can change the component that is populating this page to one that uses the /api/commons/allplus then you can certainly fill in this missing information." I thought of keeping the "CommonsOverview" and the "PlayPage" components as they are, and went with the approach mentioned above.

Closes #27 