### PR TITLE
SC - Carrying Capacity column added to Admin's List Commons page

### DIFF
--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -77,7 +77,7 @@ export default function CommonsTable({ commons, currentUser }) {
         },
         {
             Header: 'Carrying Capacity',
-            accessor: 'carryingCapacity'
+            accessor: 'commons.carryingCapacity'
         }
     ];
 

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -74,6 +74,10 @@ export default function CommonsTable({ commons, currentUser }) {
         {
             Header: 'Cows',
             accessor: 'totalCows'
+        },
+        {
+            Header: 'Carrying Capacity',
+            accessor: 'carryingCapacity'
         }
     ];
 

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -65,8 +65,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate'];
-    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate"];
+    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Carrying Capacity'];
+    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate", "carryingCapacity"];
     const testId = "CommonsTable";
 
     expectedHeaders.forEach((headerText) => {


### PR DESCRIPTION
Added 'Carrying Capacity' column to CommonsTable.js && fixed tests, to represent change, in CommonsTable.test.js
Column then appears in the List Commons page as an Admin
Blank sections in columns are from Commons created before 'Carrying Capacity' value was implemented
<img width="1318" alt="Screen Shot 2022-11-29 at 3 22 08 PM" src="https://user-images.githubusercontent.com/56518584/204670300-30625f69-39c7-43a4-a708-f242c9d3a62b.png">
