### PR TITLE
ad - Using the totalUsers field from CommonsPlus entity to display number of players in a common

### DIFF
--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -3,20 +3,20 @@ import { Row, Card, Col, Button } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
-export default function CommonsOverview({ commons, currentUser }) {
+export default function CommonsOverview({ commonsPlus, currentUser }) {
 
     let navigate = useNavigate();
     // Stryker disable next-line all
-    const leaderboardButtonClick = () => { navigate("/leaderboard/" + commons.id) };
-    const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
+    const leaderboardButtonClick = () => { navigate("/leaderboard/" + commonsPlus.commons.id) };
+    const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commonsPlus.commons.showLeaderboard );
     return (
         <Card data-testid="CommonsOverview">
             <Card.Header as="h5">Announcements</Card.Header>
             <Card.Body>
                 <Row>
                     <Col>
-                        <Card.Title>Today is day {commons.day}!</Card.Title>
-                        <Card.Text>Total Players: {commons.totalPlayers}</Card.Text>
+                        <Card.Title>Today is day {commonsPlus.commons.day}!</Card.Title>
+                        <Card.Text>Total Players: {commonsPlus.totalUsers}</Card.Text>
                     </Col>
                     <Col>
                         {showLeaderboard &&

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -45,7 +45,21 @@ export default function PlayPage() {
         }
       }
     );
-  // Stryker enable all 
+  // Stryker enable all
+
+  // Stryker disable all
+    const { data: commonsPlus } =
+      useBackend(
+        [`/api/commons/plus?id=${commonsId}`],
+        {
+          method: "GET",
+          url: "/api/commons/plus",
+          params: {
+            id: commonsId
+          }
+        }
+      );
+    // Stryker enable all
 
   // Stryker disable all 
   const { data: userCommonsProfits } =
@@ -125,7 +139,7 @@ export default function PlayPage() {
       <BasicLayout >
         <Container >
           {!!currentUser && <CommonsPlay currentUser={currentUser} />}
-          {!!commons && <CommonsOverview commons={commons} currentUser={currentUser} />}
+          {!!commonsPlus && <CommonsOverview commonsPlus={commonsPlus} currentUser={currentUser} />}
           <br />
           {!!userCommons &&
             <CardGroup >

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -6,7 +6,8 @@ import AxiosMockAdapter from "axios-mock-adapter";
 
 import CommonsOverview from "main/components/Commons/CommonsOverview"; 
 import PlayPage from "main/pages/PlayPage";
-import commonsFixtures from "fixtures/commonsFixtures"; 
+//import commonsFixtures from "fixtures/commonsFixtures";
+import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
 import leaderboardFixtures from "fixtures/leaderboardFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -33,14 +34,17 @@ describe("CommonsOverview tests", () => {
 
     test("renders without crashing", () => {
         render(
-            <CommonsOverview commons={commonsFixtures.oneCommons[0]} />
+            //<CommonsOverview commons={commonsFixtures.oneCommons[0]} />
+            <CommonsOverview commonsPlus={commonsPlusFixtures.oneCommonsPlus[0]} />
         );
     });
 
     test("Redirects to the LeaderboardPage for an admin when you click visit", async () => {
-        apiCurrentUserFixtures.adminUser.user.commons = commonsFixtures.oneCommons[0];
+        //apiCurrentUserFixtures.adminUser.user.commons = commonsFixtures.oneCommons[0];
+        apiCurrentUserFixtures.adminUser.user.commonsPlus = commonsPlusFixtures.oneCommonsPlus;
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
-        axiosMock.onGet("/api/commons", {params: {id:1}}).reply(200, commonsFixtures.oneCommons);
+        //axiosMock.onGet("/api/commons", {params: {id:1}}).reply(200, commonsFixtures.oneCommons);
+        axiosMock.onGet("/api/commons/plus", {params: {id:4}}).reply(200, commonsPlusFixtures.oneCommonsPlus);
         axiosMock.onGet("/api/leaderboard/all").reply(200, leaderboardFixtures.threeUserCommonsLB);
         render(
             <QueryClientProvider client={queryClient}>
@@ -50,7 +54,7 @@ describe("CommonsOverview tests", () => {
             </QueryClientProvider>
         );
         await waitFor(() => {
-            expect(axiosMock.history.get.length).toEqual(5);
+            expect(axiosMock.history.get.length).toEqual(6);
         });
         expect(await screen.findByTestId("user-leaderboard-button")).toBeInTheDocument();
         const leaderboardButton = screen.getByTestId("user-leaderboard-button");
@@ -59,13 +63,19 @@ describe("CommonsOverview tests", () => {
     });
 
     test("No LeaderboardPage for an ordinary user when commons has showLeaderboard = false", async () => {
-        const ourCommons = {
+        /*const ourCommons = {
             ...commonsFixtures.oneCommons,
             showLeaderboard : false
+        };*/
+        const ourCommons = {
+                    ...commonsPlusFixtures.oneCommonsPlus.commons,
+                    showLeaderboard : false
         };
-        apiCurrentUserFixtures.userOnly.user.commons = commonsFixtures.oneCommons[0];
+        //apiCurrentUserFixtures.userOnly.user.commons = commonsFixtures.oneCommons[0];
+        apiCurrentUserFixtures.userOnly.user.commonsPlus = commonsPlusFixtures.oneCommonsPlus[0];
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/commons", {params: {id:1}}).reply(200, ourCommons);
+        //axiosMock.onGet("/api/commons", {params: {id:1}}).reply(200, commonsFixtures.oneCommons);
+        axiosMock.onGet("/api/commons/plus", {params: {id:4}}).reply(200, commonsPlusFixtures.oneCommonsPlus);
         axiosMock.onGet("/api/leaderboard/all").reply(200, leaderboardFixtures.threeUserCommonsLB);
         render(
             <QueryClientProvider client={queryClient}>
@@ -75,7 +85,7 @@ describe("CommonsOverview tests", () => {
             </QueryClientProvider>
         );
         await waitFor(() => {
-            expect(axiosMock.history.get.length).toEqual(3);
+            expect(axiosMock.history.get.length).toEqual(2);
         });
         expect(() => screen.getByTestId("user-leaderboard-button")).toThrow();
     });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -41,6 +41,22 @@ describe("PlayPage tests", () => {
                 name: "Sample Commons"
             }
         ]);
+        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
+                    commons:
+                    {
+                        id: 1,
+                        name: "Sample Commons"
+                    }
+        });
+        axiosMock.onGet("/api/commons/allplus").reply(200, [
+                {
+                     commons:
+                     {
+                         id: 1,
+                         name: "Sample Commons"
+                     }
+                }
+        ]);
         axiosMock.onGet("/api/profits/all/commons").reply(200, []);
         axiosMock.onPut("/api/usercommons/sell").reply(200, userCommons);
         axiosMock.onPut("/api/usercommons/buy").reply(200, userCommons);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -136,6 +136,19 @@ public class CommonsController extends ApiController {
     return commons;
   }
 
+  @ApiOperation(value = "Get a specific commons and number of cows/users")
+  @GetMapping("/plus")
+  public ResponseEntity<String> getSingleCommonsPlus(@ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+    log.info("getSingleCommonsPlus()...");
+    Commons commons = commonsRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
+
+    CommonsPlus singleCommonsPlus = toCommonsPlus(commons);
+
+    String body = mapper.writeValueAsString(singleCommonsPlus);
+    return ResponseEntity.ok().body(body);
+  }
+
   @ApiOperation(value = "Create a new commons")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PostMapping(value = "/new", produces = "application/json")

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -754,4 +754,28 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(actualCommonsPlus, expectedCommonsPlus);
   }
 
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void getSingleCommonsPlusTest() throws Exception {
+    Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
+
+    CommonsPlus singleCommonsPlus = CommonsPlus.builder()
+        .commons(Commons1)
+        .totalCows(50)
+        .totalUsers(20)
+        .build();
+
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(Commons1));
+    when(commonsRepository.getNumCows(1L)).thenReturn(Optional.of(50));
+    when(commonsRepository.getNumUsers(1L)).thenReturn(Optional.of(20));
+
+    MvcResult response = mockMvc.perform(get("/api/commons/plus?id=1").contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(commonsRepository, times(1)).findById(eq(1L));
+
+    String responseString = response.getResponse().getContentAsString();
+    CommonsPlus actualCommonsPlus = objectMapper.readValue(responseString, CommonsPlus.class);
+    assertEquals(actualCommonsPlus, singleCommonsPlus);
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -778,4 +778,23 @@ public class CommonsControllerTests extends ControllerTestCase {
     CommonsPlus actualCommonsPlus = objectMapper.readValue(responseString, CommonsPlus.class);
     assertEquals(actualCommonsPlus, singleCommonsPlus);
   }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void getSingleCommonsPlusTest_invalid() throws Exception {
+
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.empty());
+    when(commonsRepository.getNumCows(1L)).thenReturn(Optional.empty());
+    when(commonsRepository.getNumUsers(1L)).thenReturn(Optional.empty());
+
+    MvcResult response = mockMvc.perform(get("/api/commons/plus?id=1"))
+        .andExpect(status().is(404)).andReturn();
+
+    verify(commonsRepository, times(1)).findById(eq(1L));
+
+    Map<String, Object> responseMap = responseToJson(response);
+
+    assertEquals(responseMap.get("message"), "Commons with id 1 not found");
+    assertEquals(responseMap.get("type"), "EntityNotFoundException");
+  }
 }


### PR DESCRIPTION
I made the appropriate changes as prof Conrad suggested earlier, and this time I did not introduce a new variable in the Commons entity

Closes #27 