### PR TITLE
sy - create CowDeathTable, fixtures, tests, and storybook entry

### DIFF
--- a/frontend/src/fixtures/cowDeathFixtures.js
+++ b/frontend/src/fixtures/cowDeathFixtures.js
@@ -1,0 +1,40 @@
+const cowDeathFixtures = {
+    threecowdeaths: [
+        {
+            "id": 1,
+            "commonsId": 1,
+            "userId": 7,
+            "createdAt": "2022-11-30T00:30:25.827",
+            "cowsKilled": 10,
+            "avgHealth": 70
+        },
+        {
+            "id": 2,
+            "commonsId": 2,
+            "userId": 10,
+            "createdAt": "2022-11-27T00:30:25.827",
+            "cowsKilled": 5,
+            "avgHealth": 85
+        },
+        {
+            "id": 3,
+            "commonsId": 3,
+            "userId": 19,
+            "createdAt": "2022-11-15T00:30:25.827",
+            "cowsKilled": 3,
+            "avgHealth": 90
+        }
+    ],
+    onecowdeath: [
+        {
+            "id": 1,
+            "commonsId": 1,
+            "userId": 7,
+            "createdAt": "2022-11-30T00:30:25.827",
+            "cowsKilled": 10,
+            "avgHealth": 70
+        }
+    ]
+};
+
+export default cowDeathFixtures;

--- a/frontend/src/main/components/Commons/CowDeathTable.js
+++ b/frontend/src/main/components/Commons/CowDeathTable.js
@@ -6,10 +6,6 @@ export default function CowDeathTable({ cowDeaths, currentUser }) {
 
     const columns = [
         {
-            Header: 'id',
-            accessor: 'id'
-        },
-        {
             Header: "commons id",
             accessor: "commonsId"
         },
@@ -34,6 +30,10 @@ export default function CowDeathTable({ cowDeaths, currentUser }) {
     const testid = "CowDeathTable";
 
     const columnsIfAdmin = [
+        {
+            Header: 'id',
+            accessor: 'id'
+        },
         ...columns
     ];
 

--- a/frontend/src/main/components/Commons/CowDeathTable.js
+++ b/frontend/src/main/components/Commons/CowDeathTable.js
@@ -6,12 +6,12 @@ export default function CowDeathTable({ cowDeaths, currentUser }) {
 
     const columns = [
         {
-            Header: "commons id",
-            accessor: "commonsId"
+            Header: 'id',
+            accessor: 'id'
         },
         {
-            Header: 'user id',
-            accessor: 'userId'
+            Header: "commons id",
+            accessor: "commonsId"
         },
         {
             Header:'Created At',
@@ -31,8 +31,8 @@ export default function CowDeathTable({ cowDeaths, currentUser }) {
 
     const columnsIfAdmin = [
         {
-            Header: '(admin) id',
-            accessor: 'id'
+            Header: '(admin) user id',
+            accessor: 'userId'
         },
         ...columns
     ];

--- a/frontend/src/main/components/Commons/CowDeathTable.js
+++ b/frontend/src/main/components/Commons/CowDeathTable.js
@@ -6,12 +6,12 @@ export default function CowDeathTable({ cowDeaths, currentUser }) {
 
     const columns = [
         {
-            Header: 'id',
-            accessor: 'id'
-        },
-        {
             Header: "commons id",
             accessor: "commonsId"
+        },
+        {
+            Header: 'user id',
+            accessor: 'userId'
         },
         {
             Header:'Created At',
@@ -31,8 +31,8 @@ export default function CowDeathTable({ cowDeaths, currentUser }) {
 
     const columnsIfAdmin = [
         {
-            Header: '(admin) user id',
-            accessor: 'userId'
+            Header: '(admin) id',
+            accessor: 'id'
         },
         ...columns
     ];

--- a/frontend/src/main/components/Commons/CowDeathTable.js
+++ b/frontend/src/main/components/Commons/CowDeathTable.js
@@ -1,0 +1,65 @@
+import React from "react";
+import OurTable, {ButtonColumn} from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/commonsUtils"
+//import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function CowDeathTable({ cowDeaths, currentUser }) {
+
+    // Stryker disable all : hard to test for query caching
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/cowdeath/all/bycommons"]
+    );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { 
+        console.log("deleteCallback cell=", cell);
+        deleteMutation.mutate(cell); 
+    }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id'
+        },
+        {
+            Header: "commons id",
+            accessor: "commonsId"
+        },
+        {
+            Header: 'user id',
+            accessor: 'userId'
+        },
+        {
+            Header:'Created At',
+            accessor: 'createdAt'
+        },
+        {
+            Header: 'Cows Killed',
+            accessor: 'cowsKilled'
+        },
+        {
+            Header: 'Average Health',
+            accessor: 'avgHealth'
+        }
+    ];
+
+    const testid = "CowDeathTable";
+
+    const columnsIfAdmin = [
+        ...columns,
+        ButtonColumn("Delete", "danger", deleteCallback, testid)
+    ];
+
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+
+    return <OurTable
+        data={cowDeaths}
+        columns={columnsToDisplay}
+        testid={testid}
+    />;
+}

--- a/frontend/src/main/components/Commons/CowDeathTable.js
+++ b/frontend/src/main/components/Commons/CowDeathTable.js
@@ -31,7 +31,7 @@ export default function CowDeathTable({ cowDeaths, currentUser }) {
 
     const columnsIfAdmin = [
         {
-            Header: 'id',
+            Header: '(admin) id',
             accessor: 'id'
         },
         ...columns

--- a/frontend/src/main/components/Commons/CowDeathTable.js
+++ b/frontend/src/main/components/Commons/CowDeathTable.js
@@ -1,25 +1,8 @@
 import React from "react";
-import OurTable, {ButtonColumn} from "main/components/OurTable";
-import { useBackendMutation } from "main/utils/useBackend";
-import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/commonsUtils"
-//import { useNavigate } from "react-router-dom";
+import OurTable from "main/components/OurTable";
 import { hasRole } from "main/utils/currentUser";
 
 export default function CowDeathTable({ cowDeaths, currentUser }) {
-
-    // Stryker disable all : hard to test for query caching
-    const deleteMutation = useBackendMutation(
-        cellToAxiosParamsDelete,
-        { onSuccess: onDeleteSuccess },
-        ["/api/cowdeath/all/bycommons"]
-    );
-    // Stryker enable all 
-
-    // Stryker disable next-line all : TODO try to make a good test for this
-    const deleteCallback = async (cell) => { 
-        console.log("deleteCallback cell=", cell);
-        deleteMutation.mutate(cell); 
-    }
 
     const columns = [
         {
@@ -51,8 +34,7 @@ export default function CowDeathTable({ cowDeaths, currentUser }) {
     const testid = "CowDeathTable";
 
     const columnsIfAdmin = [
-        ...columns,
-        ButtonColumn("Delete", "danger", deleteCallback, testid)
+        ...columns
     ];
 
     const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,16 +48,8 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, 
-    '&::before': {
-      content: "",
-      position: "absolute",
-      left: 0,
-      right: 0,
-      top: 0,
-      bottom: 0,
-      backgroundColor: "rgba(255,255,255,1)",
-    }}}>
+    <div style={{ backgroundSize: 'cover', background: linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.5)), backgroundImage: `url(${Background})`, 
+}}>
         <BasicLayout>
             <div className="pt-2">
                 <h1>Leaderboard</h1>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,15 +48,15 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: 'relative', 
-    '&::after': {
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, 
+    '&::before': {
       content: "",
       position: "absolute",
       left: 0,
       right: 0,
       top: 0,
       bottom: 0,
-      backgroundColor: "rgba(255,255,255,0.5)",
+      backgroundColor: "rgba(255,255,255,1)",
     }}}>
         <BasicLayout>
             <div className="pt-2">

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,17 +48,20 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', background: linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.5)), backgroundImage: `url(${Background})`, 
-}}>
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
         <BasicLayout>
-            <div className="pt-2">
-                <h1>Leaderboard</h1>
-                {
-                  showLeaderboard?
-                  (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser}/>) :
-                  (<p>You're not authorized to see the leaderboard.</p>)
-                }
-            </div>
+          <Container>
+            <Card>
+              <div className="pt-2">
+                  <h1>Leaderboard</h1>
+                  {
+                    showLeaderboard?
+                    (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser}/>) :
+                    (<p>You're not authorized to see the leaderboard.</p>)
+                  }
+              </div>
+            </Card>
+          </Container>
         </BasicLayout>
     </div>
   )

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -49,7 +49,7 @@ export default function LeaderboardPage() {
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
     <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: 'relative', 
-    '&::before': {
+    '&::after': {
       content: "",
       position: "absolute",
       left: 0,

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,7 +48,7 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: relative, 
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: 'relative', 
     '&::before': {
       content: "",
       position: "absolute",

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Container, Card } from "react-bootstrap";
 
 import { useParams } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,13 +48,22 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, color:"white", 
+    '&::before': {
+      content: "",
+      position: "absolute",
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      background: "rgba(255,255,255,0.5)",
+    }}}>
         <BasicLayout>
             <div className="pt-2">
                 <h1>Leaderboard</h1>
                 {
                   showLeaderboard?
-                  (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />) :
+                  (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser}/>) :
                   (<p>You're not authorized to see the leaderboard.</p>)
                 }
             </div>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,7 +48,7 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, color:"white", 
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, position: relative, 
     '&::before': {
       content: "",
       position: "absolute",
@@ -56,7 +56,7 @@ export default function LeaderboardPage() {
       right: 0,
       top: 0,
       bottom: 0,
-      background: "rgba(255,255,255,0.5)",
+      backgroundColor: "rgba(255,255,255,0.5)",
     }}}>
         <BasicLayout>
             <div className="pt-2">

--- a/frontend/src/stories/components/Commons/CowDeathTable.stories.js
+++ b/frontend/src/stories/components/Commons/CowDeathTable.stories.js
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import CowDeathTable from "main/components/Commons/CowDeathTable";
+import cowDeathFixtures from 'fixtures/cowDeathFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'components/commons/CowDeathTable',
+    component: CowDeathTable
+};
+
+const Template = (args) => {
+    return (
+        <CowDeathTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    cowDeaths: []
+};
+
+export const ThreeCowDeaths = Template.bind({});
+
+ThreeCowDeaths.args = {
+    cowDeaths: cowDeathFixtures.threecowdeaths
+};
+
+export const OneCowDeath = Template.bind({});
+
+OneCowDeath.args = {
+    cowDeaths: cowDeathFixtures.onecowdeath
+}
+
+export const ThreeCowDeathsAdmin = Template.bind({});
+
+ThreeCowDeathsAdmin.args = {
+    cowDeaths: cowDeathFixtures.threecowdeaths,
+    currentUser: currentUserFixtures.adminUser
+};
+
+export const OneCowDeathAdmin = Template.bind({});
+
+OneCowDeathAdmin.args = {
+    cowDeaths: cowDeathFixtures.onecowdeath,
+    currentUser: currentUserFixtures.adminUser
+}

--- a/frontend/src/tests/components/Commons/CowDeathTable.test.js
+++ b/frontend/src/tests/components/Commons/CowDeathTable.test.js
@@ -66,7 +66,7 @@ describe("CowDeathTable tests", () => {
     
         );
 
-        const expectedHeaders = ["id", "commons id", "user id", 'Created At', 'Cows Killed', 'Average Health'];
+        const expectedHeaders = ["id", "commons id", "(admin) user id", 'Created At', 'Cows Killed', 'Average Health'];
         const expectedFields = ["id", "commonsId", "userId", "createdAt", "cowsKilled", "avgHealth"];
         const testId = "CowDeathTable";
 

--- a/frontend/src/tests/components/Commons/CowDeathTable.test.js
+++ b/frontend/src/tests/components/Commons/CowDeathTable.test.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import CowDeathTable from "main/components/Commons/CowDeathTable"
@@ -71,20 +71,20 @@ describe("CowDeathTable tests", () => {
         const testId = "CowDeathTable";
 
         expectedHeaders.forEach((headerText) => {
-            const header = getByText(headerText);
+            const header = screen.getByText(headerText);
             expect(header).toBeInTheDocument();
         });
 
         expectedFields.forEach((field) => {
-            const header = getByTestId(`${testId}-cell-row-0-col-commons.${field}`);
+            const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
             expect(header).toBeInTheDocument();
         });
 
-        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
 
-        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
         expect(deleteButton).toHaveClass("btn-danger");
     });

--- a/frontend/src/tests/components/Commons/CowDeathTable.test.js
+++ b/frontend/src/tests/components/Commons/CowDeathTable.test.js
@@ -66,7 +66,7 @@ describe("CowDeathTable tests", () => {
     
         );
 
-        const expectedHeaders = ["id", "commons id", "(admin) user id", 'Created At', 'Cows Killed', 'Average Health'];
+        const expectedHeaders = ["(admin) id", "commons id", "user id", 'Created At', 'Cows Killed', 'Average Health'];
         const expectedFields = ["id", "commonsId", "userId", "createdAt", "cowsKilled", "avgHealth"];
         const testId = "CowDeathTable";
 

--- a/frontend/src/tests/components/Commons/CowDeathTable.test.js
+++ b/frontend/src/tests/components/Commons/CowDeathTable.test.js
@@ -83,9 +83,5 @@ describe("CowDeathTable tests", () => {
         expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
         expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
         expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
-
-        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-        expect(deleteButton).toBeInTheDocument();
-        expect(deleteButton).toHaveClass("btn-danger");
     });
 });

--- a/frontend/src/tests/components/Commons/CowDeathTable.test.js
+++ b/frontend/src/tests/components/Commons/CowDeathTable.test.js
@@ -1,0 +1,91 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import CowDeathTable from "main/components/Commons/CowDeathTable"
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import cowDeathFixtures from "fixtures/cowDeathFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("CowDeathTable tests", () => {
+    const queryClient = new QueryClient();
+  
+    test("renders without crashing for empty table with user not logged in", () => {
+      const currentUser = null;
+  
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <CowDeathTable cowDeaths={[]} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+  
+      );
+    });
+
+    test("renders without crashing for empty table for ordinary user", () => {
+        const currentUser = currentUserFixtures.userOnly;
+    
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <CowDeathTable cowDeaths={[]} currentUser={currentUser} />
+            </MemoryRouter>
+          </QueryClientProvider>
+    
+        );
+      });
+
+      test("renders without crashing for empty table for admin", () => {
+        const currentUser = currentUserFixtures.adminUser;
+    
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <CowDeathTable cowDeaths={[]} currentUser={currentUser} />
+            </MemoryRouter>
+          </QueryClientProvider>
+    
+        );
+      });
+
+      test("Has the expected column headers and content for adminUser", () => {
+        const currentUser = currentUserFixtures.adminUser;
+    
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <CowDeathTable cowDeaths={cowDeathFixtures.threecowdeaths} currentUser={currentUser} />
+            </MemoryRouter>
+          </QueryClientProvider>
+    
+        );
+
+        const expectedHeaders = ["id", "commons id", "user id", 'Created At', 'Cows Killed', 'Average Health'];
+        const expectedFields = ["id", "commonsId", "userId", "createdAt", "cowsKilled", "avgHealth"];
+        const testId = "CowDeathTable";
+
+        expectedHeaders.forEach((headerText) => {
+            const header = getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach((field) => {
+            const header = getByTestId(`${testId}-cell-row-0-col-commons.${field}`);
+            expect(header).toBeInTheDocument();
+        });
+
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+        expect(deleteButton).toHaveClass("btn-danger");
+    });
+});


### PR DESCRIPTION
In this PR, a new React component called CowDeathTable is created, which should display a list of CowDeaths in the format returned by the GET endpoints.

Admins should be able to see all cow deaths for a commons. Users should be able to cow deaths for their own user commons.

The fixtures, tests, and a storybook entry are also created.

Link to the storybook entry:
[https://ucsb-cs156-f22.github.io/f22-6pm-happycows-docs-qa/storybook-qa/shialan-cowdeathtable/?path=/story/components-commons-cowdeathtable--empty](https://ucsb-cs156-f22.github.io/f22-6pm-happycows-docs-qa/storybook-qa/shialan-cowdeathtable/?path=/story/components-commons-cowdeathtable--empty)

Closes #49 