### PR TITLE
pc - createdAt should not be input, but instead automatically populated

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CowDeathController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CowDeathController.java
@@ -46,7 +46,6 @@ public class CowDeathController extends ApiController {
     @PostMapping("/admin/post")
     public CowDeath postCowDeath_admin(
             @ApiParam("commonsId") @RequestParam Long commonsId,
-            @ApiParam("createdAt") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) ZonedDateTime createdAt,
             @ApiParam("cowsKilled") @RequestParam Integer cowsKilled,
             @ApiParam("avgHealth") @RequestParam Long avgHealth) {
         
@@ -57,7 +56,6 @@ public class CowDeathController extends ApiController {
         CowDeath createdCowDeath = CowDeath.builder()
             .commonsId(commonsId)
             .userId(userId)
-            .createdAt(createdAt)
             .cowsKilled(cowsKilled)
             .avgHealth(avgHealth)
             .build();

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
@@ -81,7 +81,7 @@ public class CowDeathControllerTests extends ControllerTestCase {
             .id(0)
             .commonsId(2)
             .userId(1)
-            .createdAt(ldt1)
+            .createdAt(null)
             .cowsKilled(2)
             .avgHealth(4)
             .build();


### PR DESCRIPTION
In this PR, we offer a suggestion for adjusting the createdAt date field in cow deaths so that it is automatically populated with the time the cow death record is created.