### PR TITLE
Irene cow death controller pc2

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CowDeathController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CowDeathController.java
@@ -46,7 +46,6 @@ public class CowDeathController extends ApiController {
     @PostMapping("/admin/post")
     public CowDeath postCowDeath_admin(
             @ApiParam("commonsId") @RequestParam Long commonsId,
-            @ApiParam("createdAt") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) ZonedDateTime createdAt,
             @ApiParam("cowsKilled") @RequestParam Integer cowsKilled,
             @ApiParam("avgHealth") @RequestParam Long avgHealth) {
         
@@ -57,7 +56,6 @@ public class CowDeathController extends ApiController {
         CowDeath createdCowDeath = CowDeath.builder()
             .commonsId(commonsId)
             .userId(userId)
-            .createdAt(createdAt)
             .cowsKilled(cowsKilled)
             .avgHealth(avgHealth)
             .build();

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
@@ -67,20 +67,19 @@ public class CowDeathControllerTests extends ControllerTestCase {
     @MockBean
     CommonsRepository commonsRepository;
 
+    private LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    private LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
+
     @WithMockUser(roles = { "ADMIN" })
     @Test
     public void post_cowdeaths_admin_post() throws Exception {
 
-        ZonedDateTime ldt1 = ZonedDateTime.parse("2016-10-05T08:20:10+05:30[UTC]");
-        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-        LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
-
-
-        UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
+       
+        UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(17).build();
         CowDeath expectedCowDeath = CowDeath.builder()
             .id(0)
             .commonsId(2)
-            .userId(1)
+            .userId(17)
             .createdAt(null)
             .cowsKilled(2)
             .avgHealth(4)
@@ -97,11 +96,20 @@ public class CowDeathControllerTests extends ControllerTestCase {
             .showLeaderboard(false)
             .build();
 
+        User user1 = User.builder()
+            .givenName("Chris")
+            .familyName("Gaucho")
+            .fullName("Chris Gaucho")
+            .admin(false)
+            .email("cgaucho@example.org")
+            .build();
+
         when(cowDeathRepository.save(expectedCowDeath)).thenReturn(expectedCowDeath);
         when(userCommonsRepository.findById(1L)).thenReturn(Optional.of(expectedUserCommons));
         when(commonsRepository.findById(2L)).thenReturn(Optional.of(common1));
+        when(userRepository.findById(17L)).thenReturn(Optional.of(user1));
 
-        MvcResult response = mockMvc.perform(post("/api/cowdeath/admin/post?commonsId=2&createdAt=2016-10-05T08:20:10+05:30[UTC]&cowsKilled=2&avgHealth=4")
+        MvcResult response = mockMvc.perform(post("/api/cowdeath/admin/post?commonsId=2&userId=17&cowsKilled=2&avgHealth=4")
             .with(csrf())).andExpect(status().isOk()).andReturn();
 
         verify(cowDeathRepository, times(1)).save(expectedCowDeath);
@@ -113,11 +121,54 @@ public class CowDeathControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = { "ADMIN" })
     @Test
-    public void post_cowdeaths_nonexistent_commons_admin_post() throws Exception {
+    public void post_cowdeaths_nonexistent_user_admin_post() throws Exception {
 
         ZonedDateTime ldt1 = ZonedDateTime.parse("2016-10-05T08:20:10+05:30[UTC]");
 
         UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(1).build();
+        Commons common1 = Commons.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .endingDate(someOtherTime)
+        .degradationRate(50.0)
+        .showLeaderboard(false)
+        .build();
+        
+        CowDeath expectedCowDeath = CowDeath.builder()
+            .id(0)
+            .commonsId(2)
+            .userId(1)
+            .createdAt(ldt1)
+            .cowsKilled(2)
+            .avgHealth(4)
+            .build();
+
+        when(cowDeathRepository.save(expectedCowDeath)).thenReturn(expectedCowDeath);
+        when(userCommonsRepository.findById(1L)).thenReturn(Optional.of(expectedUserCommons));
+        when(commonsRepository.findById(2L)).thenReturn(Optional.of(common1));
+
+        MvcResult response = mockMvc.perform(post("/api/cowdeath/admin/post?commonsId=2&userId=17&cowsKilled=2&avgHealth=4")
+            .with(csrf())).andExpect(status().isNotFound()).andReturn();
+
+        verify(commonsRepository, times(1)).findById(2L);
+
+        Map<String, Object> json = responseToJson(response);
+
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("User with id 17 not found", json.get("message"));    
+    
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void post_cowdeaths_nonexistent_commons_admin_post() throws Exception {
+
+        ZonedDateTime ldt1 = ZonedDateTime.parse("2016-10-05T08:20:10+05:30[UTC]");
+
+        UserCommons expectedUserCommons = UserCommons.builder().id(1).commonsId(2).userId(17).build();
         CowDeath expectedCowDeath = CowDeath.builder()
             .id(0)
             .commonsId(2)
@@ -130,7 +181,7 @@ public class CowDeathControllerTests extends ControllerTestCase {
         when(cowDeathRepository.save(expectedCowDeath)).thenReturn(expectedCowDeath);
         when(userCommonsRepository.findById(1L)).thenReturn(Optional.of(expectedUserCommons));
 
-        MvcResult response = mockMvc.perform(post("/api/cowdeath/admin/post?commonsId=2&createdAt=2016-10-05T08:20:10+05:30[UTC]&cowsKilled=2&avgHealth=4")
+        MvcResult response = mockMvc.perform(post("/api/cowdeath/admin/post?commonsId=2&userId=17&cowsKilled=2&avgHealth=4")
             .with(csrf())).andExpect(status().isNotFound()).andReturn();
 
         verify(commonsRepository, times(1)).findById(2L);
@@ -138,7 +189,9 @@ public class CowDeathControllerTests extends ControllerTestCase {
         Map<String, Object> json = responseToJson(response);
 
         assertEquals("EntityNotFoundException", json.get("type"));
-        assertEquals("Commons with id 2 not found", json.get("message"));    }
+        assertEquals("Commons with id 2 not found", json.get("message"));
+    }
+
 
     @WithMockUser(roles = { "ADMIN" })
     @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
@@ -81,7 +81,7 @@ public class CowDeathControllerTests extends ControllerTestCase {
             .id(0)
             .commonsId(2)
             .userId(1)
-            .createdAt(ldt1)
+            .createdAt(null)
             .cowsKilled(2)
             .avgHealth(4)
             .build();


### PR DESCRIPTION
In this PR, we suggest the changes needed so that admins can specify which user a CowDeath record pertains to.

This branch also contains the changes for the createdAt date in the previous PR.