### PR TITLE
pc - suggested refactoring to inject dependencies into UpdateCowHealth job

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -2,26 +2,23 @@ package edu.ucsb.cs156.happiercows.jobs;
 
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 import edu.ucsb.cs156.happiercows.entities.Commons;
-import edu.ucsb.cs156.happiercows.entities.CowDeath;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.CowDeathRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
+import lombok.Getter;
 
-@Slf4j
 @Builder
+@AllArgsConstructor
 public class UpdateCowHealthJob implements JobContextConsumer {
 
-    private CommonsRepository commonsRepository;
-    private UserCommonsRepository userCommonsRepository;
+    @Getter private CommonsRepository commonsRepository;
+    @Getter private UserCommonsRepository userCommonsRepository;
 
     @Override
     public void accept(JobContext ctx) throws Exception {

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class UpdateCowHealthJobFactory  {
+
+    @Autowired 
+    CommonsRepository commonsRepository;
+    
+    @Autowired
+    UserCommonsRepository userCommonsRepository;
+  
+    public UpdateCowHealthJob create() {
+        log.info("commonsRepository = " + commonsRepository);
+        log.info("userCommonsRepository = " + userCommonsRepository);
+        return new UpdateCowHealthJob( commonsRepository, userCommonsRepository);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+
+@RestClientTest(UpdateCowHealthJobFactory.class)
+@AutoConfigureDataJpa
+public class UpdateCowHealthJobFactoryTests {
+  
+    @Autowired
+    UpdateCowHealthJobFactory updateCowHealthJobFactory;
+
+    @MockBean 
+    CommonsRepository commonsRepository;
+    
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+
+        UpdateCowHealthJob updateCowHealthJob = updateCowHealthJobFactory.create();
+
+        // Assert
+
+        assertEquals(commonsRepository,updateCowHealthJob.getCommonsRepository());
+        assertEquals(userCommonsRepository,updateCowHealthJob.getUserCommonsRepository());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -1,30 +1,59 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
 public class UpdateCowHealthJobTests {
+
+
+    @MockBean 
+    CommonsRepository commonsRepository;
+    
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
     @Test
     void test_log_output() throws Exception {
 
         // Arrange
 
+        List<Commons> commonsList = new ArrayList<Commons>();
+
+        // TODO:  You will actually need to fill commonsList with at least one Commons object
+        // if the test is really going to test anything significant, but this is a good start.
+
+        when(commonsRepository.findAll()).thenReturn(commonsList);
+
+
         Job jobStarted = Job.builder().build();
         JobContext ctx = new JobContext(null, jobStarted);
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = UpdateCowHealthJob.builder()
-                .build();
+
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = "Starting to update cow health.\n" +
-                "This is where the code to update the cow's health will go.\n" +
+               // "This is where the code to update the cow's health will go.\n" +
                 "Cows Health has been updated!";
 
         assertEquals(expected, jobStarted.getLog());


### PR DESCRIPTION
In this PR, we suggest a way to refactor the UpdateCowHealthJob so that we can inject `@Autowired` dependencies into the `UpdateCowHealthJob` object.